### PR TITLE
use fsnotify.v0

### DIFF
--- a/adapter/file.go
+++ b/adapter/file.go
@@ -1,12 +1,13 @@
 package adapter
 
 import (
-	"code.google.com/p/go.exp/fsnotify"
-	"github.com/DonGar/go-house/options"
-	"github.com/DonGar/go-house/status"
 	"io/ioutil"
 	"log"
 	"path/filepath"
+
+	"github.com/DonGar/go-house/options"
+	"github.com/DonGar/go-house/status"
+	"gopkg.in/fsnotify.v0"
 )
 
 type fileAdapter struct {


### PR DESCRIPTION
fsnotify is currently being maintained at:
https://github.com/go-fsnotify/fsnotify

fsnotify.v0 matches the API you are using but some bugs have been fixed. There
is also a newer v1 API if you wish to upgrade.
